### PR TITLE
Use all instead of whenObjectAdded

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ repositories {
 
 dependencies {
     compile gradleApi()
-    compile 'com.android.tools.build:gradle:0.12.2'
+    compile 'com.android.tools.build:gradle:1.5.0'
     compile 'org.imgscalr:imgscalr-lib:4.2'
 }
 

--- a/src/main/java/com/github/forsety/ADRPlugin.java
+++ b/src/main/java/com/github/forsety/ADRPlugin.java
@@ -23,9 +23,9 @@ public class ADRPlugin implements Plugin<Project> {
         target.afterEvaluate(project -> {
             target.getExtensions().findByType(ADRExtension.class).validate();
             if (target.getPlugins().hasPlugin(AppPlugin.class))
-                target.getExtensions().findByType(AppExtension.class).getApplicationVariants().whenObjectAdded(appVariant -> setup(target, appVariant));
+                target.getExtensions().findByType(AppExtension.class).getApplicationVariants().all(appVariant -> setup(target, appVariant));
             else if (target.getPlugins().hasPlugin(AppPlugin.class))
-                target.getExtensions().findByType(LibraryExtension.class).getLibraryVariants().whenObjectAdded(libraryVariant -> setup(target, libraryVariant));
+                target.getExtensions().findByType(LibraryExtension.class).getLibraryVariants().all(libraryVariant -> setup(target, libraryVariant));
             else
                 throw new RuntimeException("No android plugin found");
         });


### PR DESCRIPTION
This PR is based on #3. Although the library can be applied to new projects after being compiled against the latest gradle plugin, it seems that no tasks were being registered.

Upon inspection, it seems that the function passed to whenObjectAdded was never actually called. Changing this call to all, as recommended in the documentation of the getApplicationVariants/getLibraryVariants methods, fixed the issue.
