### PR TITLE
Fix invalid library check

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ repositories {
 
 dependencies {
     compile gradleApi()
-    compile 'com.android.tools.build:gradle:0.12.2'
+    compile 'com.android.tools.build:gradle:1.5.0'
     compile 'org.imgscalr:imgscalr-lib:4.2'
 }
 

--- a/src/main/java/com/github/forsety/ADRPlugin.java
+++ b/src/main/java/com/github/forsety/ADRPlugin.java
@@ -23,9 +23,9 @@ public class ADRPlugin implements Plugin<Project> {
         target.afterEvaluate(project -> {
             target.getExtensions().findByType(ADRExtension.class).validate();
             if (target.getPlugins().hasPlugin(AppPlugin.class))
-                target.getExtensions().findByType(AppExtension.class).getApplicationVariants().whenObjectAdded(appVariant -> setup(target, appVariant));
+                target.getExtensions().findByType(AppExtension.class).getApplicationVariants().all(appVariant -> setup(target, appVariant));
             else if (target.getPlugins().hasPlugin(AppPlugin.class))
-                target.getExtensions().findByType(LibraryExtension.class).getLibraryVariants().whenObjectAdded(libraryVariant -> setup(target, libraryVariant));
+                target.getExtensions().findByType(LibraryExtension.class).getLibraryVariants().all(libraryVariant -> setup(target, libraryVariant));
             else
                 throw new RuntimeException("No android plugin found");
         });

--- a/src/main/java/com/github/forsety/ADRPlugin.java
+++ b/src/main/java/com/github/forsety/ADRPlugin.java
@@ -3,10 +3,10 @@ package com.github.forsety;
 import com.android.build.gradle.AppExtension;
 import com.android.build.gradle.AppPlugin;
 import com.android.build.gradle.LibraryExtension;
+import com.android.build.gradle.LibraryPlugin;
 import com.android.build.gradle.api.BaseVariant;
 import com.android.build.gradle.tasks.MergeResources;
 import com.github.forsety.task.ResizeDrawablesTask;
-
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 
@@ -24,7 +24,7 @@ public class ADRPlugin implements Plugin<Project> {
             target.getExtensions().findByType(ADRExtension.class).validate();
             if (target.getPlugins().hasPlugin(AppPlugin.class))
                 target.getExtensions().findByType(AppExtension.class).getApplicationVariants().all(appVariant -> setup(target, appVariant));
-            else if (target.getPlugins().hasPlugin(AppPlugin.class))
+            else if (target.getPlugins().hasPlugin(LibraryPlugin.class))
                 target.getExtensions().findByType(LibraryExtension.class).getLibraryVariants().all(libraryVariant -> setup(target, libraryVariant));
             else
                 throw new RuntimeException("No android plugin found");


### PR DESCRIPTION
This is also a continuation of #4.

When fixing issues with the latest Gradle plugin, I noticed that both branches of the if statement check for the same thing.

Based on the contents of the second block, I changed the test to check for the LibraryPlugin.
